### PR TITLE
Add example typographic styles

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -296,6 +296,8 @@ PODS:
     - React-Core (= 0.63.4)
     - React-cxxreact (= 0.63.4)
     - React-jsi (= 0.63.4)
+  - RNStaticSafeAreaInsets (2.1.1):
+    - React
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -347,6 +349,7 @@ DEPENDENCIES:
   - React-RCTText (from `../node_modules/react-native/Libraries/Text`)
   - React-RCTVibration (from `../node_modules/react-native/Libraries/Vibration`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
+  - RNStaticSafeAreaInsets (from `../node_modules/react-native-static-safe-area-insets`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -415,6 +418,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/Libraries/Vibration"
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
+  RNStaticSafeAreaInsets:
+    :path: "../node_modules/react-native-static-safe-area-insets"
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
@@ -455,6 +460,7 @@ SPEC CHECKSUMS:
   React-RCTText: 5c51df3f08cb9dedc6e790161195d12bac06101c
   React-RCTVibration: ae4f914cfe8de7d4de95ae1ea6cc8f6315d73d9d
   ReactCommon: 73d79c7039f473b76db6ff7c6b159c478acbbb3b
+  RNStaticSafeAreaInsets: 6103cf09647fa427186d30f67b0f5163c1ae8252
   Yoga: 4bd86afe9883422a7c4028c00e34790f560923d6
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "react": "16.13.1",
     "react-native": "0.63.4",
+    "react-native-static-safe-area-insets": "^2.1.1",
     "react-native-typography": "^1.4.1"
   },
   "devDependencies": {

--- a/src/BaseExample.tsx
+++ b/src/BaseExample.tsx
@@ -5,7 +5,7 @@ import { Sizing, Typography, Outlines, Colors, Buttons } from "./styles"
 
 const BaseExample: FunctionComponent = () => {
   return (
-    <View style={style.container}>
+    <View>
       <View style={style.headerContainer}>
         <Text style={style.headerText}>
           React Native Typescript Styles Example
@@ -45,9 +45,6 @@ const BaseExample: FunctionComponent = () => {
 }
 
 const style = StyleSheet.create({
-  container: {
-    marginBottom: Sizing.x80,
-  },
   headerContainer: {
     marginBottom: Sizing.x20,
     paddingBottom: Sizing.x20,
@@ -56,19 +53,16 @@ const style = StyleSheet.create({
   },
   headerText: {
     ...Typography.header.x60,
-    marginBottom: Sizing.x10,
+    marginBottom: Sizing.x20,
   },
   subheaderText: {
-    ...Typography.header.x20,
+    ...Typography.subheader.x30,
   },
   bodyContainer: {
     marginBottom: Sizing.x20,
   },
   bodyText: {
-    ...Typography.fontSize.x20,
-    ...Typography.fontWeight.regular,
-    ...Typography.lineHeight.x30,
-    color: Colors.neutral.s600,
+    ...Typography.body.x20,
     marginBottom: Sizing.x20,
   },
   button: {

--- a/src/ColorExample.tsx
+++ b/src/ColorExample.tsx
@@ -119,7 +119,7 @@ const style = StyleSheet.create({
     marginBottom: Sizing.x20,
   },
   subHeaderText: {
-    ...Typography.header.x40,
+    ...Typography.subheader.x40,
   },
   colorContainer: {
     marginBottom: Sizing.x5,

--- a/src/ColorExample.tsx
+++ b/src/ColorExample.tsx
@@ -9,7 +9,8 @@ const ColorExample: FunctionComponent = () => {
       <View style={style.headerContainer}>
         <Text style={style.headerText}>Colors</Text>
       </View>
-      <View style={style.sectionContianer}>
+
+      <View style={style.sectionContainer}>
         <View style={style.subHeaderContainer}>
           <Text style={style.subHeaderText}>Neutral</Text>
         </View>
@@ -28,7 +29,7 @@ const ColorExample: FunctionComponent = () => {
         <ColorListItem color={Colors.neutral.black} label={"black"} />
       </View>
 
-      <View style={style.sectionContianer}>
+      <View style={style.sectionContainer}>
         <View style={style.subHeaderContainer}>
           <Text style={style.subHeaderText}>Primary</Text>
         </View>
@@ -37,7 +38,7 @@ const ColorExample: FunctionComponent = () => {
         <ColorListItem color={Colors.primary.s600} label={"s600"} />
       </View>
 
-      <View style={style.sectionContianer}>
+      <View style={style.sectionContainer}>
         <View style={style.subHeaderContainer}>
           <Text style={style.subHeaderText}>Secondary</Text>
         </View>
@@ -46,28 +47,28 @@ const ColorExample: FunctionComponent = () => {
         <ColorListItem color={Colors.secondary.s600} label={"s600"} />
       </View>
 
-      <View style={style.sectionContianer}>
+      <View style={style.sectionContainer}>
         <View style={style.subHeaderContainer}>
           <Text style={style.subHeaderText}>Danger</Text>
         </View>
         <ColorListItem color={Colors.danger.s400} label={"s400"} />
       </View>
 
-      <View style={style.sectionContianer}>
+      <View style={style.sectionContainer}>
         <View style={style.subHeaderContainer}>
           <Text style={style.subHeaderText}>Success</Text>
         </View>
         <ColorListItem color={Colors.success.s400} label={"s400"} />
       </View>
 
-      <View style={style.sectionContianer}>
+      <View style={style.sectionContainer}>
         <View style={style.subHeaderContainer}>
           <Text style={style.subHeaderText}>Warning</Text>
         </View>
         <ColorListItem color={Colors.warning.s400} label={"s400"} />
       </View>
 
-      <View style={style.sectionContianer}>
+      <View style={style.sectionContainer}>
         <View style={style.subHeaderContainer}>
           <Text style={style.subHeaderText}>Transparent</Text>
         </View>
@@ -111,8 +112,8 @@ const style = StyleSheet.create({
   headerText: {
     ...Typography.header.x50,
   },
-  sectionContianer: {
-    marginBottom: Sizing.x10,
+  sectionContainer: {
+    marginBottom: Sizing.x30,
   },
   subHeaderContainer: {
     marginBottom: Sizing.x20,

--- a/src/TypographyExample.tsx
+++ b/src/TypographyExample.tsx
@@ -24,6 +24,16 @@ const TypographyExample: FunctionComponent = () => {
 
       <View style={style.sectionContainer}>
         <View style={style.subHeaderContainer}>
+          <Text style={style.subHeaderText}>Subheader</Text>
+        </View>
+        <Text style={style.x40subheader}>Subheader x40</Text>
+        <Text style={style.x30subheader}>Subheader x30</Text>
+        <Text style={style.x20subheader}>Subheader x20</Text>
+        <Text style={style.x10subheader}>Subheader x10</Text>
+      </View>
+
+      <View style={style.sectionContainer}>
+        <View style={style.subHeaderContainer}>
           <Text style={style.subHeaderText}>Body</Text>
         </View>
         <Text style={style.x40body}>Body x40</Text>
@@ -46,13 +56,13 @@ const style = StyleSheet.create({
     ...Typography.header.x50,
   },
   sectionContainer: {
-    marginBottom: Sizing.x30,
+    marginBottom: Sizing.x60,
   },
   subHeaderContainer: {
     marginBottom: Sizing.x20,
   },
   subHeaderText: {
-    ...Typography.header.x40,
+    ...Typography.subheader.x40,
   },
   x60header: {
     ...Typography.header.x60,
@@ -76,6 +86,22 @@ const style = StyleSheet.create({
   },
   x10header: {
     ...Typography.header.x10,
+    marginBottom: Sizing.x10,
+  },
+  x40subheader: {
+    ...Typography.subheader.x40,
+    marginBottom: Sizing.x10,
+  },
+  x30subheader: {
+    ...Typography.subheader.x30,
+    marginBottom: Sizing.x10,
+  },
+  x20subheader: {
+    ...Typography.subheader.x20,
+    marginBottom: Sizing.x10,
+  },
+  x10subheader: {
+    ...Typography.subheader.x10,
     marginBottom: Sizing.x10,
   },
   x40body: {

--- a/src/TypographyExample.tsx
+++ b/src/TypographyExample.tsx
@@ -1,0 +1,99 @@
+import React, { FunctionComponent } from "react"
+import { StyleSheet, View, Text } from "react-native"
+
+import { Sizing, Typography } from "./styles"
+
+const TypographyExample: FunctionComponent = () => {
+  return (
+    <View style={style.container}>
+      <View style={style.headerContainer}>
+        <Text style={style.headerText}>Typography</Text>
+      </View>
+
+      <View style={style.sectionContainer}>
+        <View style={style.subHeaderContainer}>
+          <Text style={style.subHeaderText}>Header</Text>
+        </View>
+        <Text style={style.x60header}>Header x60</Text>
+        <Text style={style.x50header}>Header x50</Text>
+        <Text style={style.x40header}>Header x40</Text>
+        <Text style={style.x30header}>Header x30</Text>
+        <Text style={style.x20header}>Header x20</Text>
+        <Text style={style.x10header}>Header x10</Text>
+      </View>
+
+      <View style={style.sectionContainer}>
+        <View style={style.subHeaderContainer}>
+          <Text style={style.subHeaderText}>Body</Text>
+        </View>
+        <Text style={style.x40body}>Body x40</Text>
+        <Text style={style.x30body}>Body x30</Text>
+        <Text style={style.x20body}>Body x20</Text>
+        <Text style={style.x10body}>Body x10</Text>
+      </View>
+    </View>
+  )
+}
+
+const style = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  headerContainer: {
+    marginBottom: Sizing.x20,
+  },
+  headerText: {
+    ...Typography.header.x50,
+  },
+  sectionContainer: {
+    marginBottom: Sizing.x30,
+  },
+  subHeaderContainer: {
+    marginBottom: Sizing.x20,
+  },
+  subHeaderText: {
+    ...Typography.header.x40,
+  },
+  x60header: {
+    ...Typography.header.x60,
+    marginBottom: Sizing.x10,
+  },
+  x50header: {
+    ...Typography.header.x50,
+    marginBottom: Sizing.x10,
+  },
+  x40header: {
+    ...Typography.header.x40,
+    marginBottom: Sizing.x10,
+  },
+  x30header: {
+    ...Typography.header.x30,
+    marginBottom: Sizing.x10,
+  },
+  x20header: {
+    ...Typography.header.x20,
+    marginBottom: Sizing.x10,
+  },
+  x10header: {
+    ...Typography.header.x10,
+    marginBottom: Sizing.x10,
+  },
+  x40body: {
+    ...Typography.body.x40,
+    marginBottom: Sizing.x10,
+  },
+  x30body: {
+    ...Typography.body.x30,
+    marginBottom: Sizing.x10,
+  },
+  x20body: {
+    ...Typography.body.x20,
+    marginBottom: Sizing.x10,
+  },
+  x10body: {
+    ...Typography.body.x10,
+    marginBottom: Sizing.x10,
+  },
+})
+
+export default TypographyExample

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,35 +1,47 @@
 import React, { FunctionComponent } from "react"
-import { ScrollView, SafeAreaView, StyleSheet, View } from "react-native"
+import { ScrollView, StyleSheet, View } from "react-native"
+import StaticSafeAreaInsets from "react-native-static-safe-area-insets"
 
 import BaseExample from "./BaseExample"
 import ColorExample from "./ColorExample"
+import TypographyExample from "./TypographyExample"
 
 import { Sizing, Outlines, Colors } from "./styles"
 
 const App: FunctionComponent = () => {
   return (
-    <SafeAreaView>
-      <ScrollView contentContainerStyle={style.contentContainer}>
-        <View style={style.sectionContainer}>
-          <BaseExample />
-        </View>
-        <View style={style.sectionContainer}>
-          <ColorExample />
-        </View>
-      </ScrollView>
-    </SafeAreaView>
+    <ScrollView
+      style={style.container}
+      contentContainerStyle={style.contentContainer}
+    >
+      <View style={style.sectionContainer}>
+        <BaseExample />
+      </View>
+      <View style={style.sectionContainer}>
+        <ColorExample />
+      </View>
+      <View style={style.sectionContainer}>
+        <TypographyExample />
+      </View>
+    </ScrollView>
   )
 }
 
+const topInset = StaticSafeAreaInsets.safeAreaInsetsTop
+
 const style = StyleSheet.create({
+  container: {
+    marginTop: topInset,
+    backgroundColor: Colors.neutral.white,
+  },
   contentContainer: {
     padding: Sizing.x20,
   },
   sectionContainer: {
-    borderBottomWidth: Outlines.borderWidth.thin,
-    borderColor: Colors.neutral.s100,
     paddingBottom: Sizing.x20,
     marginBottom: Sizing.x20,
+    borderBottomWidth: Outlines.borderWidth.thin,
+    borderColor: Colors.neutral.s100,
   },
 })
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,9 +17,11 @@ const App: FunctionComponent = () => {
       <View style={style.sectionContainer}>
         <BaseExample />
       </View>
+
       <View style={style.sectionContainer}>
         <ColorExample />
       </View>
+
       <View style={style.sectionContainer}>
         <TypographyExample />
       </View>

--- a/src/styles/buttons.ts
+++ b/src/styles/buttons.ts
@@ -26,13 +26,11 @@ export const bar: Record<Bar, ViewStyle> = {
 type BarText = "primary" | "secondary"
 export const barText: Record<BarText, TextStyle> = {
   primary: {
-    ...Typography.fontSize.x20,
-    ...Typography.fontWeight.semibold,
+    ...Typography.subheader.x20,
     color: Colors.neutral.white,
   },
   secondary: {
-    ...Typography.fontSize.x10,
-    ...Typography.fontWeight.regular,
+    ...Typography.body.x20,
     color: Colors.neutral.s500,
   },
 }

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -1,6 +1,8 @@
 import { TextStyle } from "react-native"
 import { systemWeights } from "react-native-typography"
 
+import * as Colors from "./colors"
+
 type FontSize = "x10" | "x20" | "x30" | "x40" | "x50" | "x60"
 export const fontSize: Record<FontSize, TextStyle> = {
   x10: {
@@ -39,57 +41,117 @@ export const fontWeight: Record<FontWeight, TextStyle> = {
 type LineHeight = "x10" | "x20" | "x30" | "x40" | "x50" | "x60"
 export const lineHeight: Record<LineHeight, TextStyle> = {
   x10: {
-    lineHeight: 12,
-  },
-  x20: {
     lineHeight: 18,
   },
-  x30: {
+  x20: {
     lineHeight: 22,
   },
-  x40: {
+  x30: {
     lineHeight: 26,
   },
+  x40: {
+    lineHeight: 32,
+  },
   x50: {
-    lineHeight: 36,
+    lineHeight: 38,
   },
   x60: {
-    lineHeight: 48,
+    lineHeight: 44,
   },
 }
 
-type Header = "x10" | "x20" | "x40" | "x50" | "x60"
+type Header = "x10" | "x20" | "x30" | "x40" | "x50" | "x60"
 export const header: Record<Header, TextStyle> = {
   x10: {
     ...fontSize.x10,
-    ...lineHeight.x20,
     ...fontWeight.bold,
+    ...lineHeight.x10,
   },
   x20: {
     ...fontSize.x20,
+    ...fontWeight.bold,
+    ...lineHeight.x20,
+  },
+  x30: {
+    ...fontSize.x30,
+    ...fontWeight.bold,
     ...lineHeight.x30,
-    ...fontWeight.semibold,
   },
   x40: {
     ...fontSize.x40,
+    ...fontWeight.bold,
     ...lineHeight.x40,
-    ...fontWeight.semibold,
   },
   x50: {
     ...fontSize.x50,
-    ...lineHeight.x50,
     ...fontWeight.bold,
+    ...lineHeight.x50,
   },
   x60: {
     ...fontSize.x60,
-    ...lineHeight.x60,
     ...fontWeight.bold,
+    ...lineHeight.x60,
   },
 }
 
-type Body = "x10"
+type Subheader = "x10" | "x20" | "x30" | "x40" | "x50" | "x60"
+export const subheader: Record<Subheader, TextStyle> = {
+  x10: {
+    ...fontSize.x10,
+    ...fontWeight.semibold,
+    ...lineHeight.x10,
+  },
+  x20: {
+    ...fontSize.x20,
+    ...fontWeight.semibold,
+    ...lineHeight.x20,
+  },
+  x30: {
+    ...fontSize.x30,
+    ...fontWeight.semibold,
+    ...lineHeight.x30,
+  },
+  x40: {
+    ...fontSize.x40,
+    ...fontWeight.semibold,
+    ...lineHeight.x40,
+  },
+  x50: {
+    ...fontSize.x50,
+    ...fontWeight.semibold,
+    ...lineHeight.x50,
+  },
+  x60: {
+    ...fontSize.x60,
+    ...fontWeight.semibold,
+    ...lineHeight.x60,
+  },
+}
+
+type Body = "x10" | "x20" | "x30" | "x40"
 export const body: Record<Body, TextStyle> = {
   x10: {
     ...fontSize.x10,
+    ...fontWeight.regular,
+    ...lineHeight.x10,
+    color: Colors.neutral.s800,
+  },
+  x20: {
+    ...fontSize.x20,
+    ...fontWeight.regular,
+    ...lineHeight.x20,
+    color: Colors.neutral.s800,
+  },
+  x30: {
+    ...fontSize.x30,
+    ...fontWeight.regular,
+    ...lineHeight.x30,
+    color: Colors.neutral.s800,
+  },
+  x40: {
+    ...fontSize.x40,
+    ...fontWeight.regular,
+    ...lineHeight.x40,
+    color: Colors.neutral.s800,
   },
 }

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -94,7 +94,7 @@ export const header: Record<Header, TextStyle> = {
   },
 }
 
-type Subheader = "x10" | "x20" | "x30" | "x40" | "x50" | "x60"
+type Subheader = "x10" | "x20" | "x30" | "x40"
 export const subheader: Record<Subheader, TextStyle> = {
   x10: {
     ...fontSize.x10,
@@ -115,16 +115,6 @@ export const subheader: Record<Subheader, TextStyle> = {
     ...fontSize.x40,
     ...fontWeight.semibold,
     ...lineHeight.x40,
-  },
-  x50: {
-    ...fontSize.x50,
-    ...fontWeight.semibold,
-    ...lineHeight.x50,
-  },
-  x60: {
-    ...fontSize.x60,
-    ...fontWeight.semibold,
-    ...lineHeight.x60,
   },
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4481,6 +4481,11 @@ react-is@^16.12.0, react-is@^16.8.1, react-is@^16.8.4:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-native-static-safe-area-insets@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/react-native-static-safe-area-insets/-/react-native-static-safe-area-insets-2.1.1.tgz#394a3510c7029288895bbaccf1dadf4fa46c4b88"
+  integrity sha512-NUSRNZp+0IJOuLeoHoU4kw/cY9g7ozUo2ApCbJAiPyYbkbv49S8gdAcZRkeR0nqwzFDA07sCZCbPI03iEV0RTQ==
+
 react-native-typography@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/react-native-typography/-/react-native-typography-1.4.1.tgz#2d05cb5935a2f7fdb6b43bbde93d60f1324578e3"


### PR DESCRIPTION
This commit updates typographic styles and adds a section with examples.

Once this is merged we should update the styles-only repo with the style updates.

<img width="380" alt="Screen Shot 2021-01-13 at 5 37 15 PM" src="https://user-images.githubusercontent.com/39350030/104518646-0161bc00-55c6-11eb-946e-ce03d60f8096.png">